### PR TITLE
Automated testing

### DIFF
--- a/.github/workflows/pythonlinters.yml
+++ b/.github/workflows/pythonlinters.yml
@@ -1,0 +1,46 @@
+# This workflow will install Python dependencies, run tests and lint with
+# a variety of Python versions For more information see:
+# https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python linting
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install poetry
+        poetry install
+        # pyre requires python-3.8+ and poetry doesn't know that we're only testing under python-3.8
+        python -m pip install pyre-check
+
+    # For now pylint is run on codacy
+
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        poetry run flake8 ansibulled --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings.
+        poetry run flake8 ansibulled --count --exit-zero --max-complexity=10 --max-line-length=100 --statistics
+
+    - name: Lint with pyre
+      run: |
+        pyre --source-directory ansibulled --search-path $(poetry run python -c 'from distutils.sysconfig import get_python_lib;print(get_python_lib())')
+      if: always()

--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -1,0 +1,37 @@
+# This workflow will install Python dependencies, run tests and lint with
+# a variety of Python versions For more information see:
+# https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python testing
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Need to separate out 3.8-only code before this works
+        #python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install poetry
+        poetry install
+    - name: Test with pytest and upload coverage stats
+      run: |
+        poetry run python -m pytest --cov-branch --cov ansibulled -vv tests
+        poetry run coverage xml
+        poetry run codecov --token=${{ secrets.CODECOV_TOKEN }}

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,10 @@
+[mypy]
+
+[mypy-sh.*]
+ignore_missing_imports = True
+
+[mypy-aiofiles.*]
+ignore_missing_imports = True
+
+[mypy-semantic_version.*]
+ignore_missing_imports = True

--- a/ansibulled/build_acd_commands.py
+++ b/ansibulled/build_acd_commands.py
@@ -119,6 +119,7 @@ def build_single_command(args):
     if not str(args.acd_version).startswith(build_acd_version):
         print(f'{args.build_file} is for version {build_acd_version} but we need'
               ' {args.acd_version.major}.{arg.acd_version.minor}')
+        return 1
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         download_dir = os.path.join(tmp_dir, 'collections')
@@ -251,7 +252,8 @@ def build_multiple_command(args):
 
     if not str(args.acd_version).startswith(build_acd_version):
         print(f'{args.build_file} is for version {build_acd_version} but we need'
-              f' {args.acd_version.major}.{arg.acd_version.minor}')
+              f' {args.acd_version.major}.{args.acd_version.minor}')
+        return 1
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         download_dir = os.path.join(tmp_dir, 'collections')

--- a/ansibulled/cli/ansibulled.py
+++ b/ansibulled/cli/ansibulled.py
@@ -7,6 +7,7 @@
 import argparse
 import os.path
 import sys
+from typing import List
 
 import packaging.version as pypiver
 
@@ -77,7 +78,7 @@ def _normalize_collection_build_options(args):
             args.deps_file = DEFAULT_FILE_BASE + f'{args.acd_version}.deps'
 
 
-def parse_args(program_name, args):
+def parse_args(program_name: str, args: List[str]) -> argparse.Namespace:
     common_parser = argparse.ArgumentParser(add_help=False)
     common_parser.add_argument('acd_version', type=pypiver.Version,
                                help='The X.Y.Z version of ACD that this will be for')
@@ -122,24 +123,24 @@ def parse_args(program_name, args):
                                    help='File which contains the list of collections and'
                                    ' versions which were included in this version of ACD')
 
-    args = parser.parse_args(args)
+    parsed_args: argparse.Namespace = parser.parse_args(args)
 
     #
     # Validation and coercion
     #
 
-    _normalize_common_options(args)
-    _normalize_new_release_options(args)
-    _normalize_release_build_options(args)
-    _normalize_collection_build_options(args)
+    _normalize_common_options(parsed_args)
+    _normalize_new_release_options(parsed_args)
+    _normalize_release_build_options(parsed_args)
+    _normalize_collection_build_options(parsed_args)
 
-    return args
+    return parsed_args
 
 
-def run(args):
+def run(args: List[str]) -> int:
     program_name = os.path.basename(args[0])
     try:
-        args = parse_args(program_name, args[1:])
+        args: argparse.Namespace = parse_args(program_name, args[1:])
     except InvalidArgumentError as e:
         print(e)
         return 2
@@ -147,9 +148,9 @@ def run(args):
     return ARGS_MAP[args.command](args)
 
 
-def main():
+def main() -> int:
     if sys.version_info < (3, 8):
         print('Needs Python 3.8 or later')
-        sys.exit(1)
+        return 1
 
     return run(sys.argv)

--- a/ansibulled/galaxy.py
+++ b/ansibulled/galaxy.py
@@ -21,6 +21,7 @@ GALAXY_SERVER_URL = 'https://galaxy.ansible.com/'
 class NoSuchCollection(Exception):
     pass
 
+
 class DownloadFailure(Exception):
     pass
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,10 @@
+[mypy]
+
+[mypy-sh.*]
+ignore_missing_imports = True
+
+[mypy-aiofiles.*]
+ignore_missing_imports = True
+
+[mypy-semantic_version.*]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ cryptography = "^2.9.2"
 # pytest-asyncio 0.11 has a bug.  This is the PR which fixes it.  Not yet
 # merged for -1.12 but the maintainer has said it looks correct
 pytest-asyncio = {git = "https://github.com/simonfagerholm/pytest-asyncio", rev = "fix_issue_154"}
-codacy-coverage = "^1.3.11"
 mypy = "^0.770"
 flake8 = {version = "^3.8.0-alpha.2", allow-prereleases = true}
 codecov = "^2.0.22"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,14 @@ semantic_version = "^2.8.5"
 sh = "^1.13.1"
 
 [tool.poetry.dev-dependencies]
-pytest-asyncio = "^0.11.0"
 asynctest = "^0.13.0"
 pytest = "^5.4.1"
 pytest-cov = "^2.8.1"
+cryptography = "^2.9.2"
+# pytest-asyncio 0.11 has a bug.  This is the PR which fixes it.  Not yet
+# merged for -1.12 but the maintainer has said it looks correct
+pytest-asyncio = {git = "https://github.com/simonfagerholm/pytest-asyncio", rev = "fix_issue_154"}
+codacy-coverage = "^1.3.11"
+mypy = "^0.770"
+flake8 = {version = "^3.8.0-alpha.2", allow-prereleases = true}
+codecov = "^2.0.22"


### PR DESCRIPTION
Not really.  This gets the framework into place but it needs a lot more configuring before it's complete.

This adds checks for:
* static type checking (via pyre.  pyre and pytype seem to be better than mypy).
* flake8 linting
* Run unittests via pytest
* Upload coverage

Things that will need to be done in a followon commit:
* More tests so that we get the coverage metrics up to a better level
* Split unit and integration tests and send them to codecov.io in a way that codecov can tell the difference
* pylint
* Look into sonarcloud.  It may be able to give us useful reviews but I haven't figured out how to configure it yet.
* If codacy gets back to me that they can get rid of the need for ssh key write, I could switch to them and not worry about sonarcloud.