### PR TITLE
Fix ansible-base versioning in the setup.py template

### DIFF
--- a/ansibulled/data/acd-setup_py.j2
+++ b/ansibulled/data/acd-setup_py.j2
@@ -27,7 +27,7 @@ setup(
     packages=['ansible_collections'],
     include_package_data=True,
     install_requires=[
-        'ansible-base>={{ version }},<{{ version.next_minor() }}',{{ collection_deps }}
+        'ansible-base>={{ version }},<{{ version.major }}.{{ version.minor + 1 }}',{{ collection_deps }}
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
We changed the ansible-base version from a semantic_version version to a
packaging.version version.  Need to adapt to the attributes and versions
that that provides.