### PR TITLE
More checking

### DIFF
--- a/.github/workflows/pythonlinters.yml
+++ b/.github/workflows/pythonlinters.yml
@@ -6,9 +6,9 @@ name: Python linting
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
@@ -18,29 +18,28 @@ jobs:
         python-version: [3.8]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install poetry
-        poetry install
-        # pyre requires python-3.8+ and poetry doesn't know that we're only testing under python-3.8
-        python -m pip install pyre-check
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install poetry
+          poetry install
 
-    # For now pylint is run on codacy
+      - name: Lint with flake8
+        run: |
+          poetry run flake8 ansibulled --count --max-complexity=10 --max-line-length=100 --statistics
 
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        poetry run flake8 ansibulled --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings.
-        poetry run flake8 ansibulled --count --exit-zero --max-complexity=10 --max-line-length=100 --statistics
+      - name: Lint with pyre
+        run: |
+          poetry run pyre --source-directory ansibulled --search-path $(poetry run python -c 'from distutils.sysconfig import get_python_lib;print(get_python_lib())')
+        if: always()
 
-    - name: Lint with pyre
-      run: |
-        pyre --source-directory ansibulled --search-path $(poetry run python -c 'from distutils.sysconfig import get_python_lib;print(get_python_lib())')
-      if: always()
+      # note: pylint is run informationally, never to fail the build
+      - name: Lint with pylint
+        run: |
+          poetry run pylint ansibulled || :
+        if: always()

--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -6,32 +6,32 @@ name: Python testing
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Need to separate out 3.8-only code before this works
-        #python-version: [3.5, 3.6, 3.7, 3.8]
-        python-version: [3.8]
+        # Need to separate out 3.8-only code as we add tests for files which
+        # have 3.8 syntax in them
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install poetry
-        poetry install
-    - name: Test with pytest and upload coverage stats
-      run: |
-        poetry run python -m pytest --cov-branch --cov ansibulled -vv tests
-        poetry run coverage xml
-        poetry run codecov --token=${{ secrets.CODECOV_TOKEN }}
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install poetry
+          poetry install
+      - name: Test with pytest and upload coverage stats
+        run: |
+          poetry run python -m pytest --cov-branch --cov ansibulled -vv tests
+          poetry run coverage xml
+          poetry run codecov --token=${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Test with pytest and upload coverage stats
         run: |
           poetry run python -m pytest --cov-branch --cov ansibulled -vv tests
-          poetry run coverage xml
+          poetry run coverage xml -i
           poetry run codecov --token=${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ packages = [
 ansibulled = "ansibulled.cli.ansibulled:main"
 
 [tool.poetry.dependencies]
-python = "^3.5.3"
+python = "^3.6.0"
 aiofiles = "^0.5.0"
 aiohttp = "^3.6.2"
 jinja2 = "^2.11.2"
@@ -32,9 +32,8 @@ asynctest = "^0.13.0"
 pytest = "^5.4.1"
 pytest-cov = "^2.8.1"
 cryptography = "^2.9.2"
-# pytest-asyncio 0.11 has a bug.  This is the PR which fixes it.  Not yet
-# merged for -1.12 but the maintainer has said it looks correct
-pytest-asyncio = {git = "https://github.com/simonfagerholm/pytest-asyncio", rev = "fix_issue_154"}
-mypy = "^0.770"
+pytest-asyncio = "^0.12"
 flake8 = {version = "^3.8.0-alpha.2", allow-prereleases = true}
 codecov = "^2.0.22"
+pyre-check = "^0.0.46"
+pylint = "^2.5.2"


### PR DESCRIPTION
Update dependencies and add more checking

* I got the okay to require python-3.6+ for the docs build so we now
  require that.
* Install pyre via poetry so that we can manage our type checker via
  poetry
  * Run pyre under poetry in our linting github action
* Make flake8 fail the build as it has a managable amount of complaining
  (We can either comply or tell it no)
* Run pylint via the linter in an advisory capacity
* Continuing to add type checking to things that will be used by the docs
  build
