### PR TITLE
Add support for release_date to changelog.yaml linter and to specs

### DIFF
--- a/ansibulled/changelog/changes.py
+++ b/ansibulled/changelog/changes.py
@@ -162,7 +162,7 @@ class ChangesBase(metaclass=abc.ABCMeta):
         """
         if version not in self.releases:
             self.releases[version] = dict(
-                release_date=str(release_date),
+                release_date=release_date.isoformat(),
             )
             if codename is not None:
                 self.releases[version]['codename'] = codename

--- a/ansibulled/changelog/lint.py
+++ b/ansibulled/changelog/lint.py
@@ -8,6 +8,8 @@
 Linting for changelog.yaml.
 """
 
+import re
+
 from typing import cast, Any, List, Optional, Tuple, Type
 
 import semantic_version
@@ -16,6 +18,9 @@ import yaml
 from .ansible import get_documentable_plugins
 from .config import ChangelogConfig
 from .fragment import ChangelogFragment, ChangelogFragmentLinter
+
+
+ISO_DATE_REGEX = re.compile('^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])$')
 
 
 class ChangelogYamlLinter:
@@ -147,6 +152,15 @@ class ChangelogYamlLinter:
         :arg version_str: The version this entry belongs to
         :arg entry: The releases list entry
         """
+        release_date = entry.get('release_date')
+        if self.verify_type(release_date, (str, ),
+                            ['releases', version_str, 'release_date']):
+            release_date = cast(str, release_date)
+            if not ISO_DATE_REGEX.match(release_date):
+                self.errors.append((self.path, 0, 0, '{0} must be a ISO date (YYYY-MM-DD)'.format(
+                    self._format_yaml_path(['releases', version_str, 'release_date'])
+                )))
+
         codename = entry.get('codename')
         self.verify_type(codename, (str, ),
                          ['releases', version_str, 'codename'], allow_none=True)

--- a/docs/changelog.yaml-format.md
+++ b/docs/changelog.yaml-format.md
@@ -44,17 +44,19 @@ releases:
 
 For a release `x.y.z`, the `releases` dictionary contains an entry `x.y.z` mapping to another dictionary. That dictionary can have the following entries:
 
+1. `release_date`: a string in ISO format (`YYYY-MM-DD`) specifying on which date the release was made.
 1. `codename`: a string for the version's codename. Optional; mainly required for ansible-base.
-2. `fragments`: a list of strings mentioning changelog fragment files used for this release. This is not used for compiling a changelog.
-3. `changes`: a dictionary containing all changes. See below.
-4. `modules`: a list of plugin dictionaries. See below.
-5. `plugins`: a dictionary mapping plugin types to lists of plugin dictionaries. See below.
+1. `fragments`: a list of strings mentioning changelog fragment files used for this release. This is not used for compiling a changelog.
+1. `changes`: a dictionary containing all changes. See below.
+1. `modules`: a list of plugin dictionaries. See below.
+1. `plugins`: a dictionary mapping plugin types to lists of plugin dictionaries. See below.
 
 The following is an example of release information for version `1.0.0`:
 
 ```.yaml
 releases:
   1.0.0:
+    release_date: 2020-04-01
     codename: White Rabbit
     changes:
       release_summary: This is the initial White Rabbit release. Enjoy!


### PR DESCRIPTION
I overlooked it when writing the specs and the linter.