### PR TITLE
Add pyre search path for ansibulled itself

### DIFF
--- a/lint-pyre.sh
+++ b/lint-pyre.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-poetry run pyre --source-directory ansibulled --search-path $(poetry run python -c 'from distutils.sysconfig import get_python_lib;print(get_python_lib())') --search-path stubs/
+poetry run pyre --source-directory ansibulled --search-path $(poetry run python -c 'from distutils.sysconfig import get_python_lib;print(get_python_lib())') --search-path stubs/ --search-path .


### PR DESCRIPTION
For pyre to resolve imports to modules that are in the toplevel
directory search path as pyre, we have to specify the path that the
ansibulled python package dir resides in as a search-path as well as as
the source-directory.