### PR TITLE
Streamline schema api

### DIFF
--- a/ansibulled/schemas/ansible_doc.py
+++ b/ansibulled/schemas/ansible_doc.py
@@ -11,9 +11,9 @@
 import typing as t
 
 from .base import BaseModel
-from .callback_docs import CallbackSchema
-from .module_docs import ModuleSchema
-from .plugin_docs import PluginSchema
+from .callback import CallbackSchema
+from .module import ModuleSchema
+from .plugin import PluginSchema
 
 
 class AnsibleDocSchema(BaseModel):

--- a/ansibulled/schemas/base.py
+++ b/ansibulled/schemas/base.py
@@ -34,7 +34,7 @@ One example of doing all this:
 .. code-block:: pycon
 
     >>> import sh, jinja2
-    >>> from ablebaker.schemas import ansible_doc
+    >>> from ansibulled.schemas import ansible_doc
     >>> template = jinja2.Template('{{ name }} -- {{ doc["short_description"] }}')
     >>> module_json = sh.ansible_doc('-t', 'module', '--json', 'yum').stdout
     >>> module_model = ansible_doc.ModulePluginSchema.parse_raw(module_json)

--- a/ansibulled/schemas/callback.py
+++ b/ansibulled/schemas/callback.py
@@ -9,7 +9,7 @@ import typing as t
 import pydantic as p
 
 from .base import BaseModel, LocalConfig, transform_return_docs
-from .plugin_docs import PluginDocSchema, PluginReturnSchema
+from .plugin import PluginDocSchema, PluginReturnSchema
 
 REQUIRED_CALLBACK_TYPE_F = p.Field(..., regex='^(aggregate|notification|stdout)$')
 

--- a/ansibulled/schemas/docs.py
+++ b/ansibulled/schemas/docs.py
@@ -1,0 +1,45 @@
+# coding: utf-8
+# Author: Toshio Kuratomi <tkuratom@redhat.com>
+# License: GPLv3+
+# Copyright: Ansible Project, 2020
+"""
+Schemas for the plugin DOCUMENTATION data.
+
+This is a highlevel interface.  The hope is that eventually people can use either this or
+ansibulled.  Right now that's probably infeasible because people will want to validate a smaller
+piece of the docs so that they can recover from errors (for instance, validate the docs, examples,
+metadta, and returndocs separately.  Only fail if docs doesn't validate.
+"""
+
+from .plugin import PluginSchema
+from .callback import CallbackSchema
+from .module import ModuleSchema
+
+
+BecomeSchema = PluginSchema
+CacheSchema = PluginSchema
+CliConfSchema = PluginSchema
+ConnectionSchema = PluginSchema
+HttpApiSchema = PluginSchema
+InventorySchema = PluginSchema
+LookupSchema = PluginSchema
+NetConfSchema = PluginSchema
+ShellSchema = PluginSchema
+StrategySchema = PluginSchema
+VarsSchema = PluginSchema
+
+SCHEMAS = {
+    'become': PluginSchema,
+    'cache': PluginSchema,
+    'callback': CallbackSchema,
+    'cliconf': PluginSchema,
+    'connection': PluginSchema,
+    'httpapi': PluginSchema,
+    'inventory': PluginSchema,
+    'lookup': PluginSchema,
+    'module': ModuleSchema,
+    'netconf': PluginSchema,
+    'shell': PluginSchema,
+    'strategy': PluginSchema,
+    'vars': PluginSchema,
+}

--- a/ansibulled/schemas/module.py
+++ b/ansibulled/schemas/module.py
@@ -9,7 +9,7 @@ import typing as t
 import pydantic as p
 
 from .base import (BaseModel, DocSchema, LocalConfig, OptionsSchema, transform_return_docs)
-from .plugin_docs import PluginReturnSchema
+from .plugin import PluginReturnSchema
 
 
 class InnerModuleOptionsSchema(OptionsSchema):

--- a/ansibulled/schemas/plugin.py
+++ b/ansibulled/schemas/plugin.py
@@ -119,6 +119,7 @@ class PluginSchema(BaseModel):
     class Config(LocalConfig):
         fields = {'return_': 'return',
                   }
+
     doc: PluginDocSchema
     examples: str = ''
     metadata: t.Optional[t.Dict[str, t.Any]] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ sh = "*"
 docutils = "*"
 rstcheck = "^3"
 PyYAML = "*"
-pydantic = "^1.5.1"
+pydantic = "*"
 
 [tool.poetry.dev-dependencies]
 asynctest = "^0.13.0"


### PR DESCRIPTION

* Rename the schema files holding lower level schemas
* Add a second highlevel interface in schema.docs as an alternative to
  the ansible-doc ones.
* Unresolved, how to use smaller pieces of this interface: if people
  want to validate just the DOCUMENTATION from an Inventory Plugin, for
  instance (possible because someone may want to display just that
  portion of docs if the return docs or eaxmples fail to validate.
