### PR TITLE
Add trivial category support to the changelog generator

### DIFF
--- a/ansibulled/changelog/config.py
+++ b/ansibulled/changelog/config.py
@@ -114,6 +114,7 @@ class ChangelogConfig:
     changelog_filename_template: str
     changelog_filename_version_depth: int
     mention_ancestor: bool
+    trivial_section_name: str
     release_tag_re: str
     pre_release_tag_re: str
     sections: Mapping[str, str]
@@ -138,6 +139,7 @@ class ChangelogConfig:
         self.changelog_filename_version_depth = self.config.get(
             'changelog_filename_version_depth', 2)
         self.mention_ancestor = self.config.get('mention_ancestor', True)
+        self.trivial_section_name = self.config.get('trivial_section_name', 'trivial')
 
         # The following are only relevant for ansible-base:
         self.release_tag_re = self.config.get(
@@ -171,6 +173,7 @@ class ChangelogConfig:
             'prelude_section_name': self.prelude_name,
             'prelude_section_title': self.prelude_title,
             'new_plugins_after_name': self.new_plugins_after_name,
+            'trivial_section_name': self.trivial_section_name,
         }
         if not self.is_collection:
             config.update({

--- a/ansibulled/changelog/fragment.py
+++ b/ansibulled/changelog/fragment.py
@@ -117,7 +117,7 @@ class ChangelogFragmentLinter:
                                'section "%s" must be type list '
                                'not %s' % (section, type(lines).__name__)))
 
-            if section not in self.config.sections:
+            if section not in self.config.sections and section != self.config.trivial_section_name:
                 errors.append((fragment.path, 0, 0, 'invalid section: %s' % section))
 
     @staticmethod

--- a/docs/changelog.yaml-format.md
+++ b/docs/changelog.yaml-format.md
@@ -111,8 +111,9 @@ The `changes` dictionary contains different sections of the changelog for this v
 6. `removed_features`: a list of strings describing features removed in this release. The features should have been deprecated earlier. This should only appear for major releases (x.0.0) as these are breaking changes.
 7. `security_fixes`: a list of strings describing security-relevant bugfixes. If available, they should include the issue's CVE.
 8. `bugfixes`: a list of strings describing other bugfixes.
+9. `trivial`: a list of strings describing changes that are too trivial to show in the changelog.
 
-Note that not every section has to be used. Also note that the sections `deprecated_features` and `security_fixes` have been added only after Ansible 2.9.
+Note that not every section has to be used. Also note that the sections `deprecated_features`, `security_fixes` and `trivial` have been added only after Ansible 2.9, and that `trivial` is special in the sense that changes in there will not be shown to the user.
 
 Every of these sections - except `release_summary` - should contain a *list* of strings. Every string in this list, as well as the `release_summary` section itself, must be valid [reStructuredText](https://en.wikipedia.org/wiki/ReStructuredText). Every string should be one line only, except for `release_summary`.
 

--- a/docs/changelogs.rst
+++ b/docs/changelogs.rst
@@ -53,7 +53,7 @@ Changelog Fragment Categories
 
 This section describes the section categories created in the default config. You can change them, though this is strongly discouraged for collections which will be included in the Ansible Community Distribution.
 
-The categories are very similar to the ones in the `Ansible-base changelog fragments <https://docs.ansible.com/ansible/latest/community/development_process.html#changelogs-how-to>`_. In fact, they are the same, except that there are two new categories: ``breaking_changes`` and ``security_fixes``.
+The categories are very similar to the ones in the `Ansible-base changelog fragments <https://docs.ansible.com/ansible/latest/community/development_process.html#changelogs-how-to>`_. In fact, they are the same, except that there are three new categories: ``breaking_changes``, ``security_fixes`` and ``trivial``.
 
 The full list of categories is:
 
@@ -83,3 +83,6 @@ The full list of categories is:
 
 **known_issues**
   This category should mention known issues that are currently not fixed or will not be fixed.
+
+**trivial**
+  This category will **not be shown** in the changelog. It can be used to describe changes that are not touching user-facing code, like changes in tests. This is useful if every PR is required to have a changelog fragment.


### PR DESCRIPTION
As discussed [in the extra DaWGs meeting](https://github.com/ansible/community/issues/521#issuecomment-631644780).