### PR TITLE
Rework the schemas so that consumers can validate the elements of a plugin's documentation

### DIFF
--- a/ansibulled/schemas/ansible_doc.py
+++ b/ansibulled/schemas/ansible_doc.py
@@ -2,7 +2,12 @@
 # Author: Toshio Kuratomi <tkuratom@redhat.com>
 # License: GPLv3+
 # Copyright: Ansible Project, 2020
-"""Schemas for the plugin DOCUMENTATION data."""
+"""
+Schemas for the plugin DOCUMENTATION data.
+
+This is a highlevel interface.  The hope is that developers can use either this or
+ansibulled.schemas.docs to handle all of their validation needs.
+"""
 
 # Ignore Unitialized attribute errors because BaseModel works some magic
 # to initialize the attributes when data is loaded into them.
@@ -28,6 +33,12 @@ class AnsibleDocSchema(BaseModel):
         plugin_type:
             plugin_name:
                 # json.loads(ansible-doc -t plugin_type --json plugin_name)
+
+    Pass the dict above to :meth:`AnsibleDocSchema.parse_obj` to build the models from the schema.
+
+    If you want to use the Schema to validate and normalize the data but need a :python:obj:`dict`
+    afterwards, call :meth:`AnsibleDocSchema.dict` on the populated model to get
+    a :python:obj:`dict` back out.
     """
 
     become: t.Dict[str, PluginSchema]
@@ -50,13 +61,39 @@ class GenericPluginSchema(BaseModel):
     Document the output of ``ansible-doc -t PLUGIN_TYPE PLUGIN_NAME``.
 
     .. note:: Both the model and the dict will be wrapped in an outer dict with your data mapped
-        to the ``__root`` key. This happens because the toplevel key of ansible-doc's output is
+        to the ``__root__`` key. This happens because the toplevel key of ansible-doc's output is
         a dynamic key which we can't automatically map to an attribute name.
     """
 
     __root__: t.Dict[str, PluginSchema]
 
 
+class CallbackPluginSchema(BaseModel):
+    """
+    Document the output of ``ansible-doc -t callback CALLBACK_NAME``.
+
+    .. note:: Both the model and the dict will be wrapped in an outer dict with your data mapped
+        to the ``__root__`` key. This happens because the toplevel key of ansible-doc's output is
+        a dynamic key which we can't automatically map to an attribute name.
+    """
+
+    __root__: t.Dict[str, CallbackSchema]
+
+
+class ModulePluginSchema(BaseModel):
+    """
+    Document the output of ``ansible-doc -t module MODULE_NAME``.
+
+    .. note:: Both the model and the dict will be wrapped in an outer dict with your data mapped
+        to the ``__root__`` key. This happens because the toplevel key of ansible-doc's output is
+        a dynamic key which we can't automatically map to an attribute name.
+    """
+
+    __root__: t.Dict[str, ModuleSchema]
+
+
+#: Make sure users can access plugins using the plugin type rather than having to guess that
+#: these types use the GenericPluginSchema
 BecomePluginSchema = GenericPluginSchema
 CachePluginSchema = GenericPluginSchema
 CliConfPluginSchema = GenericPluginSchema
@@ -70,25 +107,20 @@ StrategyPluginSchema = GenericPluginSchema
 VarsPluginSchema = GenericPluginSchema
 
 
-class CallbackPluginSchema(BaseModel):
-    """
-    Document the output of ``ansible-doc -t callback CALLBACK_NAME``.
-
-    .. note:: Both the model and the dict will be wrapped in an outer dict with your data mapped
-        to the ``__root`` key. This happens because the toplevel key of ansible-doc's output is
-        a dynamic key which we can't automatically map to an attribute name.
-    """
-
-    __root__: t.Dict[str, CallbackSchema]
-
-
-class ModulePluginSchema(BaseModel):
-    """
-    Document the output of ``ansible-doc -t module MODULE_NAME``.
-
-    .. note:: Both the model and the dict will be wrapped in an outer dict with your data mapped
-        to the ``__root`` key. This happens because the toplevel key of ansible-doc's output is
-        a dynamic key which we can't automatically map to an attribute name.
-    """
-
-    __root__: t.Dict[str, ModuleSchema]
+#: A mapping from plugin type to the Schema to use for them.  Use this to more easily get
+#: the Schema programmatically.
+ANSIBLE_DOC_SCHEMAS = {
+    'become': BecomePluginSchema,
+    'cache': CachePluginSchema,
+    'callback': CallbackPluginSchema,
+    'cliconf': CliConfPluginSchema,
+    'connection': ConnectionPluginSchema,
+    'httpapi': HttpApiPluginSchema,
+    'inventory': InventoryPluginSchema,
+    'lookup': LookupPluginSchema,
+    'module': ModulePluginSchema,
+    'netconf': NetConfPluginSchema,
+    'shell': ShellPluginSchema,
+    'strategy': StrategyPluginSchema,
+    'vars': VarsPluginSchema,
+}

--- a/ansibulled/schemas/callback.py
+++ b/ansibulled/schemas/callback.py
@@ -4,41 +4,32 @@
 # Copyright: Ansible Project, 2020
 """Schemas for the plugin DOCUMENTATION data."""
 
-import typing as t
-
 import pydantic as p
 
-from .base import BaseModel, LocalConfig, transform_return_docs
-from .plugin import PluginDocSchema, PluginReturnSchema
+from .base import BaseModel
+from .plugin import InnerDocSchema, PluginExamplesSchema, PluginMetadataSchema, PluginReturnSchema
 
 REQUIRED_CALLBACK_TYPE_F = p.Field(..., regex='^(aggregate|notification|stdout)$')
 
 
-class CallbackDocSchema(PluginDocSchema):
+class InnerCallbackDocSchema(InnerDocSchema):
+    """
+    Schema describing the structure of callback documentation.
+
+    Differs from other plugins because callbacks have subtypes documented in ``type`` rather than
+    having separate types.
+    """
+
     type: str = REQUIRED_CALLBACK_TYPE_F
 
 
 # Ignore Uninitialized attribute error as BaseModel works some magic to initialize the
 # attributes when data is loaded into them.
 # pyre-ignore[13]
-class CallbackSchema(BaseModel):
+class CallbackDocSchema(BaseModel):
+    doc: InnerCallbackDocSchema
+
+
+class CallbackSchema(CallbackDocSchema, PluginExamplesSchema, PluginMetadataSchema,
+                     PluginReturnSchema, BaseModel):
     """Documentation of callback plugins."""
-
-    class Config(LocalConfig):
-        fields = {'return_': 'return',
-                  }
-
-    doc: CallbackDocSchema
-    examples: str = ''
-    metadata: t.Optional[t.Dict[str, t.Any]] = None
-    return_: t.Dict[str, PluginReturnSchema] = {}
-
-    @p.validator('return_', pre=True)
-    def transform_return(cls, obj):
-        return transform_return_docs(obj)
-
-    @p.validator('examples', pre=True)
-    def normalize_examples(cls, value):
-        if value is None:
-            value = ''
-        return value

--- a/ansibulled/schemas/docs.py
+++ b/ansibulled/schemas/docs.py
@@ -5,16 +5,14 @@
 """
 Schemas for the plugin DOCUMENTATION data.
 
-This is a highlevel interface.  The hope is that eventually people can use either this or
-ansibulled.  Right now that's probably infeasible because people will want to validate a smaller
-piece of the docs so that they can recover from errors (for instance, validate the docs, examples,
-metadta, and returndocs separately.  Only fail if docs doesn't validate.
+This is a highlevel interface.  The hope is that developers can use either this or
+ansibulled.schemas.ansible_doc to handle all of their validation needs.
 """
 
-from .plugin import PluginSchema
-from .callback import CallbackSchema
-from .module import ModuleSchema
-
+from .callback import CallbackDocSchema, CallbackSchema
+from .module import ModuleDocSchema, ModuleSchema
+from .plugin import (PluginDocSchema, PluginExamplesSchema,
+                     PluginMetadataSchema, PluginReturnSchema, PluginSchema)
 
 BecomeSchema = PluginSchema
 CacheSchema = PluginSchema
@@ -28,18 +26,45 @@ ShellSchema = PluginSchema
 StrategySchema = PluginSchema
 VarsSchema = PluginSchema
 
-SCHEMAS = {
-    'become': PluginSchema,
-    'cache': PluginSchema,
-    'callback': CallbackSchema,
-    'cliconf': PluginSchema,
-    'connection': PluginSchema,
-    'httpapi': PluginSchema,
-    'inventory': PluginSchema,
-    'lookup': PluginSchema,
-    'module': ModuleSchema,
-    'netconf': PluginSchema,
-    'shell': PluginSchema,
-    'strategy': PluginSchema,
-    'vars': PluginSchema,
+
+#: The schemas that most plugins use to validate and normalize their documentation.
+_PLUGIN_SCHEMA_RECORD = {
+    'top': PluginSchema,
+    'doc': PluginDocSchema,
+    'example': PluginExamplesSchema,
+    'metadata': PluginMetadataSchema,
+    'return': PluginReturnSchema,
+}
+
+
+#: Mapping of plugin_types to the schemas which validate and normalize their documentation.
+#: The structure of this mapping is a two level nested dict.  The outer key is the plugin_type.
+#: The inner keys are the sections of the documentation (doc, example, metadata, return, or top
+#: [which combines all of hte above, such as ansible-doc returns]) to validate.
+DOCS_SCHEMAS = {
+    'become': _PLUGIN_SCHEMA_RECORD,
+    'cache': _PLUGIN_SCHEMA_RECORD,
+    'callback': {
+        'top': CallbackSchema,
+        'doc': CallbackDocSchema,
+        'example': PluginExamplesSchema,
+        'metadata': PluginMetadataSchema,
+        'return': PluginReturnSchema,
+    },
+    'cliconf': _PLUGIN_SCHEMA_RECORD,
+    'connection': _PLUGIN_SCHEMA_RECORD,
+    'httpapi': _PLUGIN_SCHEMA_RECORD,
+    'inventory': _PLUGIN_SCHEMA_RECORD,
+    'lookup': _PLUGIN_SCHEMA_RECORD,
+    'module': {
+        'top': ModuleSchema,
+        'doc': ModuleDocSchema,
+        'example': PluginExamplesSchema,
+        'metadata': PluginMetadataSchema,
+        'return': PluginReturnSchema,
+    },
+    'netconf': _PLUGIN_SCHEMA_RECORD,
+    'shell': _PLUGIN_SCHEMA_RECORD,
+    'strategy': _PLUGIN_SCHEMA_RECORD,
+    'vars': _PLUGIN_SCHEMA_RECORD,
 }

--- a/docs/schemas.rst
+++ b/docs/schemas.rst
@@ -1,0 +1,38 @@
+.. automodule:: ansibulled.schemas.base
+
+There is a dictionary named ANSIBLE_DOC_SCHEMAS to allow you easier access to these
+programmatically.  It is a mapping of plugin types to the ansible_doc schema which handle it.
+For example, this is the entry for modules:
+
+.. code-block: python
+
+    {'module': ModulePluginSchema}
+
+
+?If you want to validate individual plugins, use ansibulled.schemas.docs?
+:${PLUGIN_TYPE}Schema: if you want to validate individual sections of the ansible-doc output (doc,
+    examples, metadata, return)
+
+If you want to validate individual sections of plugins, retrieve the individual components of
+the schema from the higher level schema you imported.
+.. code-block:: yaml
+    module:
+        top: ModulePluginSchema
+        doc: ModuleDocSchema
+        examples: PluginExamplesSchema
+        metadata: PluginMetadataSchema
+        return: PluginReturnSchema
+
+
+Lowlevel
+========
+
+These are the implementation details.  Most Ansible plugins share a common documentation format.
+Thus, there are only three sets of classes here.  As a user, you will likely not use these directly.
+Use one of the upper ones instead.  As a contributor looking to modify the schemas, this is useful
+information as it explains how the functionality is implemented.
+
+* Callback -- Ansible Callback Plugin Documentation
+* Module -- Ansible Module Documentation
+* Plugin -- Generic Plugins.  The remaining plugins are aliases to this set of classes in the higher
+  level interfaces.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,8 @@ codecov = "^2.0.22"
 pyre-check = "^0.0.46"
 pylint = "^2.5.2"
 mypy = "^0.770"
+
+[tool.isort]
+line_length = 100
+multi_line_output = 0
+balanced_wrapping = true


### PR DESCRIPTION
These changes allow doc, elements, metadata, and return to be validated
independently.
