### PR TITLE
Normalization of the test and lint scripts

### DIFF
--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -32,6 +32,6 @@ jobs:
           poetry install
       - name: Test with pytest and upload coverage stats
         run: |
-          poetry run python -m pytest --cov-branch --cov ansibulled -vv tests
+          ./test-pytest.sh
           poetry run coverage xml -i
           poetry run codecov --token=${{ secrets.CODECOV_TOKEN }}

--- a/lint-flake8.sh
+++ b/lint-flake8.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-poetry run flake8 ansibulled --count --max-complexity=10 --max-line-length=100 --statistics
+poetry run flake8 ansibulled --count --max-complexity=10 --max-line-length=100 --statistics "$@"

--- a/lint-mypy.sh
+++ b/lint-mypy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-MYPYPATH=stubs/ poetry run mypy ansibulled
+MYPYPATH=stubs/ poetry run mypy ansibulled "$@"

--- a/lint-pylint.sh
+++ b/lint-pylint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-poetry run pylint --rcfile .pylintrc.automated ansibulled
+poetry run pylint --rcfile .pylintrc.automated ansibulled "$@"

--- a/lint-pyre.sh
+++ b/lint-pyre.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-poetry run pyre --source-directory ansibulled --search-path $(poetry run python -c 'from distutils.sysconfig import get_python_lib;print(get_python_lib())') --search-path stubs/ --search-path .
+poetry run pyre --source-directory ansibulled --search-path $(poetry run python -c 'from distutils.sysconfig import get_python_lib;print(get_python_lib())') --search-path stubs/ --search-path . "$@"

--- a/test-pytest.sh
+++ b/test-pytest.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+poetry run python -m pytest --cov-branch --cov=ansibulled -vv tests "$@"

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-args=${1-tests}
-python3.8 -m pytest --cov-branch --cov=ansibulled $args -vv


### PR DESCRIPTION
* All scripts can now be given extra arguments which they pass on to the
  lint and test programs they invoke.
* Invoke pytest in the github action via the test script.
* Rename the test script to test-pytest.sh to be more like the lint-*
  scripts.