### PR TITLE
Remove galaxy.yml dependency

### DIFF
--- a/ansibulled/changelog/changelog_generator.py
+++ b/ansibulled/changelog/changelog_generator.py
@@ -19,9 +19,10 @@ import semantic_version
 from .config import PathsConfig, ChangelogConfig
 from .changes import ChangesBase, ChangesMetadata, FragmentResolver, PluginResolver
 from .fragment import ChangelogFragment
+from .logger import LOGGER
 from .plugins import PluginDescription
 from .rst import RstBuilder
-from .utils import LOGGER, is_release_version
+from .utils import is_release_version
 
 
 class ChangelogGenerator:

--- a/ansibulled/changelog/errors.py
+++ b/ansibulled/changelog/errors.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Author: Felix Fontein <felix@fontein.de>
+# License: GPLv3+
+# Copyright: Ansible Project, 2020
+
+"""
+Error classes.
+"""
+
+
+class ChangelogError(Exception):
+    """
+    Generic error class.
+    """

--- a/ansibulled/changelog/lint.py
+++ b/ansibulled/changelog/lint.py
@@ -16,7 +16,7 @@ import semantic_version
 import yaml
 
 from .ansible import get_documentable_plugins
-from .config import ChangelogConfig
+from .config import ChangelogConfig, CollectionDetails, PathsConfig
 from .fragment import ChangelogFragment, ChangelogFragmentLinter
 
 
@@ -229,7 +229,8 @@ class ChangelogYamlLinter:
         else:
             ancestor = None
 
-        config = ChangelogConfig.default()
+        paths = PathsConfig.force_collection('')  # path doesn't matter
+        config = ChangelogConfig.default(paths, CollectionDetails(paths))
         fragment_linter = ChangelogFragmentLinter(config)
 
         if self.verify_type(changelog_yaml.get('releases'), (dict, ), ['releases']):

--- a/ansibulled/changelog/logger.py
+++ b/ansibulled/changelog/logger.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# Author: Felix Fontein <felix@fontein.de>
+# License: GPLv3+
+# Copyright: Ansible Project, 2020
+
+"""
+Provide global logger.
+"""
+
+import logging
+import sys
+
+
+class FormattingAdapter(logging.LoggerAdapter):
+    """
+    By default, the logging framework does not allow to format messages
+    other than by % formatting, except by jumping through loops. This
+    makes {} formatting work with the least amount of work.
+
+    The idea is similar to the one in https://stackoverflow.com/a/24683360
+    """
+
+    def __init__(self, logger):
+        super().__init__(logger, {})
+        self.logger_args = ['exc_info', 'extra', 'stack_info']
+
+    def log(self, level, msg, *args, **kwargs):
+        """
+        Forward log calls with formatted message.
+        """
+        if self.isEnabledFor(level):
+            log_kwargs = {
+                key: kwargs[key] for key in self.logger_args if key in kwargs
+            }
+            self.logger._log(  # pylint: disable=protected-access
+                level, msg.format(*args, **kwargs), (), **log_kwargs)
+
+    def addHandler(self, *args, **kwargs):  # pylint: disable=invalid-name
+        """
+        Forward addHandler call.
+        """
+        self.logger.addHandler(*args, **kwargs)
+
+
+LOGGER = FormattingAdapter(logging.getLogger('changelog'))
+
+
+def setup_logger(verbosity: int) -> None:
+    """
+    Setup logger.
+    """
+    formatter = logging.Formatter('%(levelname)s %(message)s')
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
+
+    LOGGER.addHandler(handler)
+    LOGGER.setLevel(logging.WARN)
+
+    if verbosity > 2:
+        LOGGER.setLevel(logging.DEBUG)
+    elif verbosity > 1:
+        LOGGER.setLevel(logging.INFO)
+    elif verbosity > 0:
+        LOGGER.setLevel(logging.WARN)

--- a/ansibulled/changelog/plugins.py
+++ b/ansibulled/changelog/plugins.py
@@ -17,8 +17,8 @@ from typing import Any, Dict, List, Optional
 import yaml
 
 from .ansible import get_documentable_plugins
-from .config import PathsConfig
-from .utils import ChangelogError, LOGGER, load_galaxy_metadata
+from .config import CollectionDetails, PathsConfig
+from .logger import LOGGER
 
 
 class PluginDescription:
@@ -245,12 +245,15 @@ def load_plugin_metadata(paths: PathsConfig, plugin_type: str,
     return result
 
 
-def load_plugins(paths: PathsConfig, version: str,
+def load_plugins(paths: PathsConfig,
+                 collection_details: CollectionDetails,
+                 version: str,
                  force_reload: bool = False) -> List[PluginDescription]:
     """
     Load plugins from ansible-doc.
 
     :arg paths: Paths configuration
+    :arg collection_details: Collection details
     :arg version: The current version. Used for caching data
     :arg force_reload: Set to ``True`` to ignore potentially cached data
     :return: A list of all plugins
@@ -275,12 +278,8 @@ def load_plugins(paths: PathsConfig, version: str,
 
         collection_name: Optional[str] = None
         if paths.is_collection:
-            try:
-                galaxy = load_galaxy_metadata(paths)
-                collection_name = '{0}.{1}'.format(galaxy['namespace'], galaxy['name'])
-            except Exception as exc:  # pylint: disable=broad-except
-                raise ChangelogError(
-                    'Error while extracting collection name from galaxy.yml: {}'.format(exc))
+            collection_name = '{}.{}'.format(
+                collection_details.get_namespace(), collection_details.get_name())
 
         for plugin_type in get_documentable_plugins():
             plugins_data['plugins'][plugin_type] = load_plugin_metadata(

--- a/ansibulled/changelog/utils.py
+++ b/ansibulled/changelog/utils.py
@@ -8,58 +8,11 @@
 Utility functions.
 """
 
-import logging
 import re
 
 import semantic_version
-import yaml
 
-from .config import PathsConfig, ChangelogConfig
-
-
-class FormattingAdapter(logging.LoggerAdapter):
-    """
-    By default, the logging framework does not allow to format messages
-    other than by % formatting, except by jumping through loops. This
-    makes {} formatting work with the least amount of work.
-
-    The idea is similar to the one in https://stackoverflow.com/a/24683360
-    """
-
-    def __init__(self, logger):
-        self.logger = logger
-        self.logger_args = ['exc_info', 'extra', 'stack_info']
-
-    def log(self, level, msg, *args, **kwargs):
-        if self.isEnabledFor(level):
-            log_kwargs = {
-                key: kwargs[key] for key in self.logger_args if key in kwargs
-            }
-            self.logger._log(level, msg.format(*args, **kwargs), (), **log_kwargs)
-
-    def addHandler(self, *args, **kwargs):
-        self.logger.addHandler(*args, **kwargs)
-
-
-class ChangelogError(Exception):
-    pass
-
-
-LOGGER = FormattingAdapter(logging.getLogger('changelog'))
-
-
-def load_galaxy_metadata(paths: PathsConfig) -> dict:
-    """
-    Load galaxy.yml metadata.
-
-    :arg paths: Paths configuration.
-    :return: The contents of ``galaxy.yaml``.
-    """
-    path = paths.galaxy_path
-    if path is None:
-        raise ValueError('Cannot find galaxy.yml')
-    with open(path, 'r') as galaxy_fd:
-        return yaml.safe_load(galaxy_fd)
+from .config import ChangelogConfig
 
 
 def is_release_version(config: ChangelogConfig, version: str) -> bool:

--- a/ansibulled/changelog/utils.py
+++ b/ansibulled/changelog/utils.py
@@ -41,6 +41,10 @@ class FormattingAdapter(logging.LoggerAdapter):
         self.logger.addHandler(*args, **kwargs)
 
 
+class ChangelogError(Exception):
+    pass
+
+
 LOGGER = FormattingAdapter(logging.getLogger('changelog'))
 
 

--- a/ansibulled/changelog/utils.py
+++ b/ansibulled/changelog/utils.py
@@ -57,7 +57,7 @@ def load_galaxy_metadata(paths: PathsConfig) -> dict:
     """
     path = paths.galaxy_path
     if path is None:
-        raise ValueError('Path configuration is not for a collection')
+        raise ValueError('Cannot find galaxy.yml')
     with open(path, 'r') as galaxy_fd:
         return yaml.safe_load(galaxy_fd)
 

--- a/ansibulled/cli/ansibulled_lint_changelog_yaml.py
+++ b/ansibulled/cli/ansibulled_lint_changelog_yaml.py
@@ -8,7 +8,6 @@ Entrypoint to the ansibulled-changelog script.
 """
 
 import argparse
-import logging
 import os.path
 import sys
 import traceback
@@ -22,7 +21,7 @@ except ImportError:
     HAS_ARGCOMPLETE = False
 
 from ..changelog.lint import lint_changelog_yaml
-from ..changelog.utils import LOGGER
+from ..changelog.logger import setup_logger
 
 
 def run(args: List[str]) -> int:
@@ -48,23 +47,10 @@ def run(args: List[str]) -> int:
         if HAS_ARGCOMPLETE:
             argcomplete.autocomplete(parser)
 
-        formatter = logging.Formatter('%(levelname)s %(message)s')
-
-        handler = logging.StreamHandler(sys.stdout)
-        handler.setFormatter(formatter)
-
-        LOGGER.addHandler(handler)
-        LOGGER.setLevel(logging.WARN)
-
         arguments = parser.parse_args(args[1:])
 
         verbosity = arguments.verbose
-        if arguments.verbose > 2:
-            LOGGER.setLevel(logging.DEBUG)
-        elif arguments.verbose > 1:
-            LOGGER.setLevel(logging.INFO)
-        elif arguments.verbose > 0:
-            LOGGER.setLevel(logging.WARN)
+        setup_logger(verbosity)
 
         return command_lint_changelog(arguments)
     except SystemExit as e:

--- a/tests/functional/changelog/fixtures.py
+++ b/tests/functional/changelog/fixtures.py
@@ -5,7 +5,7 @@ import pytest
 import yaml
 
 from ansibulled.cli.ansibulled_changelog import run as run_changelog_tool
-from ansibulled.changelog.config import PathsConfig, ChangelogConfig
+from ansibulled.changelog.config import PathsConfig, CollectionDetails, ChangelogConfig
 
 from typing import Any, Dict, List, Tuple, Optional, Set, Union
 
@@ -52,7 +52,7 @@ class ChangelogEnvironment:
         self.base = base_path
 
         self.paths = paths
-        self.config = ChangelogConfig.default(is_collection=is_collection)
+        self.config = ChangelogConfig.default(paths, CollectionDetails(paths))
 
         self.created_dirs = set()
         self.created_files = dict()
@@ -85,7 +85,7 @@ class ChangelogEnvironment:
         os.makedirs(config_dir, exist_ok=True)
         self.created_dirs.add(config_dir)
         self.config = config
-        self.config.store(self.paths.config_path)
+        self.config.store()
         self._written(self.paths.config_path)
 
     def add_fragment(self, fragment_name: str, content: str):
@@ -187,7 +187,9 @@ class CollectionChangelogEnvironment(ChangelogEnvironment):
             data['namespace'] = self.namespace
         if 'name' not in data:
             data['name'] = self.collection
-        self._write_yaml(self.paths.galaxy_path, data)
+        galaxy_path = os.path.join(self.paths.base_dir, 'galaxy.yml')
+        self._write_yaml(galaxy_path, data)
+        self.paths.galaxy_path = galaxy_path
 
 
 @pytest.fixture

--- a/tests/functional/changelog/test_changelog.py
+++ b/tests/functional/changelog/test_changelog.py
@@ -24,15 +24,16 @@ def test_changelog_init(collection_changelog, namespace='asfd'):
     assert config['title'] == collection_changelog.collection_name.title()
 
 
-def test_changelog_release_empty(collection_changelog, namespace='asfd'):
+def test_changelog_release_empty(collection_changelog):
     collection_changelog.set_galaxy({
         'version': '1.0.0',
     })
     collection_changelog.set_config(collection_changelog.config)
-    collection_changelog.add_fragment_line('1.0.0.yml', 'release_summary', 'This is the first proper release.')
+    collection_changelog.add_fragment_line(
+        '1.0.0.yml', 'release_summary', 'This is the first proper release.')
     collection_changelog.set_plugin_cache('1.0.0', {})
 
-    assert collection_changelog.run_tool('release', ['--date', '2020-01-02']) == 0
+    assert collection_changelog.run_tool('release', ['-v', '--date', '2020-01-02']) == 0
 
     diff = collection_changelog.diff()
     assert diff.added_dirs == []
@@ -52,12 +53,233 @@ def test_changelog_release_empty(collection_changelog, namespace='asfd'):
     assert 'codename' not in changelog['releases']['1.0.0']
 
 
-def test_changelog_release_plugin_cache(collection_changelog, namespace='asfd'):
+def test_changelog_release_simple(collection_changelog):
     collection_changelog.set_galaxy({
         'version': '1.0.0',
     })
     collection_changelog.set_config(collection_changelog.config)
-    collection_changelog.add_fragment_line('1.0.0.yml', 'release_summary', 'This is the first proper release.')
+    collection_changelog.add_fragment_line(
+        '1.0.0.yml', 'release_summary', 'This is the first proper release.')
+    collection_changelog.add_fragment_line(
+        'test-new-option.yml', 'minor_changes', ['test - has a new option ``foo``.'])
+    collection_changelog.add_fragment_line(
+        'baz-new-option.yaml', 'minor_changes', ['baz lookup - no longer ignores the ``bar`` option.'])
+    collection_changelog.set_plugin_cache('1.0.0', {
+        'module': {
+            'test': {
+                'name': 'test',
+                'description': 'This is a test module',
+                'namespace': '',
+                'version_added': '1.0.0',
+            },
+        },
+        'lookup': {
+            'bar': {
+                'name': 'bar',
+                'description': 'A foo bar lookup',
+                'namespace': None,
+                'version_added': '1.0.0',
+            },
+            'baz': {
+                'name': 'baz',
+                'description': 'Has already been here',
+                'namespace': None,
+                'version_added': None,
+            },
+        },
+    })
+
+    assert collection_changelog.run_tool('release', ['-v', '--date', '2020-01-02']) == 0
+
+    diff = collection_changelog.diff()
+    assert diff.added_dirs == []
+    assert diff.added_files == ['changelogs/CHANGELOG.rst', 'changelogs/changelog.yaml']
+    assert diff.removed_dirs == []
+    assert diff.removed_files == [
+        'changelogs/fragments/1.0.0.yml',
+        'changelogs/fragments/baz-new-option.yaml',
+        'changelogs/fragments/test-new-option.yml',
+    ]
+    assert diff.changed_files == []
+
+    changelog = diff.parse_yaml('changelogs/changelog.yaml')
+    assert changelog['ancestor'] is None
+    assert list(changelog['releases']) == ['1.0.0']
+    assert changelog['releases']['1.0.0']['release_date'] == '2020-01-02'
+    assert changelog['releases']['1.0.0']['changes'] == {
+        'release_summary': 'This is the first proper release.',
+        'minor_changes': [
+            'baz lookup - no longer ignores the ``bar`` option.',
+            'test - has a new option ``foo``.',
+        ],
+    }
+    assert changelog['releases']['1.0.0']['fragments'] == [
+        '1.0.0.yml',
+        'baz-new-option.yaml',
+        'test-new-option.yml',
+    ]
+    assert changelog['releases']['1.0.0']['modules'] == [
+        {
+            'name': 'test',
+            'description': 'This is a test module',
+            'namespace': '',
+        },
+    ]
+    assert changelog['releases']['1.0.0']['plugins'] == {
+        'lookup': [
+            {
+                'name': 'bar',
+                'description': 'A foo bar lookup',
+                'namespace': None,
+            },
+        ],
+    }
+    assert 'codename' not in changelog['releases']['1.0.0']
+
+
+def test_changelog_release_simple_no_galaxy(collection_changelog):
+    collection_changelog.set_config(collection_changelog.config)
+    collection_changelog.add_fragment_line(
+        '1.0.0.yml', 'release_summary', 'This is the first proper release.')
+    collection_changelog.add_fragment_line(
+        'test-new-option.yml', 'minor_changes', ['test - has a new option ``foo``.'])
+    collection_changelog.add_fragment_line(
+        'baz-new-option.yaml', 'minor_changes', ['baz lookup - no longer ignores the ``bar`` option.'])
+
+    # If we don't specify all options, the call will fail
+    assert collection_changelog.run_tool('release', ['-v', '--date', '2020-01-02']) == 5
+    assert collection_changelog.run_tool('release', [  # without --version
+        '-v',
+        '--date', '2020-01-02',
+        '--is-collection', 'true',
+        '--collection-namespace', 'cloud',
+        '--collection-name', 'sky',
+        '--collection-flatmap', 'yes',
+    ]) == 5
+    assert collection_changelog.run_tool('release', [  # without --is-collection
+        '-v',
+        '--date', '2020-01-02',
+        '--version', '1.0.0',
+        '--collection-namespace', 'cloud',
+        '--collection-name', 'sky',
+        '--collection-flatmap', 'yes',
+    ]) == 5
+    assert collection_changelog.run_tool('release', [  # without --collection-namespace
+        '-v',
+        '--date', '2020-01-02',
+        '--version', '1.0.0',
+        '--is-collection', 'true',
+        '--collection-name', 'sky',
+        '--collection-flatmap', 'yes',
+    ]) == 5
+    assert collection_changelog.run_tool('release', [  # without --collection-name
+        '-v',
+        '--date', '2020-01-02',
+        '--version', '1.0.0',
+        '--is-collection', 'true',
+        '--collection-namespace', 'cloud',
+        '--collection-flatmap', 'yes',
+    ]) == 5
+    assert collection_changelog.run_tool('release', [  # without --collection-flatmap
+        '-v',
+        '--date', '2020-01-02',
+        '--version', '1.0.0',
+        '--is-collection', 'true',
+        '--collection-namespace', 'cloud',
+        '--collection-name', 'sky',
+    ]) == 5
+
+    # Add plugin cache content
+    collection_changelog.set_plugin_cache('1.0.0', {
+        'module': {
+            'test': {
+                'name': 'test',
+                'description': 'This is a test module',
+                'namespace': '',
+                'version_added': '1.0.0',
+            },
+        },
+        'lookup': {
+            'bar': {
+                'name': 'bar',
+                'description': 'A foo bar lookup',
+                'namespace': None,
+                'version_added': '1.0.0',
+            },
+            'baz': {
+                'name': 'baz',
+                'description': 'Has already been here',
+                'namespace': None,
+                'version_added': None,
+            },
+        },
+    })
+
+    # If we specify all options, the call will succeed
+    assert collection_changelog.run_tool('release', [
+        '-v',
+        '--date', '2020-01-02',
+        '--version', '1.0.0',
+        '--is-collection', 'true',
+        # The following two options are not needed since the tool doesn't have to scan for plugins:
+        # '--collection-namespace', 'cloud',
+        # '--collection-name', 'sky',
+        '--collection-flatmap', 'yes',
+    ]) == 0
+
+    diff = collection_changelog.diff()
+    assert diff.added_dirs == []
+    assert diff.added_files == ['changelogs/CHANGELOG.rst', 'changelogs/changelog.yaml']
+    assert diff.removed_dirs == []
+    assert diff.removed_files == [
+        'changelogs/fragments/1.0.0.yml',
+        'changelogs/fragments/baz-new-option.yaml',
+        'changelogs/fragments/test-new-option.yml',
+    ]
+    assert diff.changed_files == []
+
+    changelog = diff.parse_yaml('changelogs/changelog.yaml')
+    assert changelog['ancestor'] is None
+    assert list(changelog['releases']) == ['1.0.0']
+    assert changelog['releases']['1.0.0']['release_date'] == '2020-01-02'
+    assert changelog['releases']['1.0.0']['changes'] == {
+        'release_summary': 'This is the first proper release.',
+        'minor_changes': [
+            'baz lookup - no longer ignores the ``bar`` option.',
+            'test - has a new option ``foo``.',
+        ],
+    }
+    assert changelog['releases']['1.0.0']['fragments'] == [
+        '1.0.0.yml',
+        'baz-new-option.yaml',
+        'test-new-option.yml',
+    ]
+    assert changelog['releases']['1.0.0']['modules'] == [
+        {
+            'name': 'test',
+            'description': 'This is a test module',
+            'namespace': '',
+        },
+    ]
+    assert changelog['releases']['1.0.0']['plugins'] == {
+        'lookup': [
+            {
+                'name': 'bar',
+                'description': 'A foo bar lookup',
+                'namespace': None,
+            },
+        ],
+    }
+    assert 'codename' not in changelog['releases']['1.0.0']
+
+
+def test_changelog_release_plugin_cache(collection_changelog):
+    collection_changelog.set_galaxy({
+        'version': '1.0.0',
+    })
+    collection_changelog.set_config(collection_changelog.config)
+    collection_changelog.add_fragment_line(
+        '1.0.0.yml', 'release_summary', 'This is the first proper release.')
     collection_changelog.add_plugin('module', 'test_module.py', create_plugin(
         DOCUMENTATION={
             'name': 'test_module',
@@ -82,7 +304,7 @@ def test_changelog_release_plugin_cache(collection_changelog, namespace='asfd'):
         RETURN={},
     ), subdirs=['cloud', 'sky'])
 
-    assert collection_changelog.run_tool('release', ['--date', '2020-01-02']) == 0
+    assert collection_changelog.run_tool('release', ['-v', '--date', '2020-01-02']) == 0
 
     diff = collection_changelog.diff()
     assert diff.added_dirs == []


### PR DESCRIPTION
Makes it possible to use the changelog tool when `galaxy.yml` is not present (except for `init` call).